### PR TITLE
Add force_destroy = true to all storage buckets

### DIFF
--- a/storage.tf
+++ b/storage.tf
@@ -14,6 +14,8 @@ resource "google_storage_bucket" "pb_s3_bucket" {
   project  = var.project_id
   location = var.region
   labels   = merge(var.labels, { component = "pocketbase", purpose = "primary-storage" })
+
+  force_destroy = true
 }
 
 data "google_storage_bucket" "pb_s3_bucket" {
@@ -29,6 +31,8 @@ resource "google_storage_bucket" "pb_backups_bucket" {
   project  = var.project_id
   location = var.region
   labels   = merge(var.labels, { component = "pocketbase", purpose = "backups" })
+
+  force_destroy = true
 }
 
 data "google_storage_bucket" "pb_backups_bucket" {

--- a/storage.tf
+++ b/storage.tf
@@ -3,6 +3,8 @@ resource "google_storage_bucket" "pb_litestream_bucket" {
   project  = var.project_id
   location = var.region
   labels   = merge(var.labels, { component = "pocketbase", purpose = "litestream-storage" })
+
+  force_destroy = true
 }
 
 # create if user did not supply s3_bucket


### PR DESCRIPTION
## Summary
- Added `force_destroy = true` to `pb_s3_bucket` and `pb_backups_bucket` resources
- Provides consistency with the existing `pb_litestream_bucket` configuration
- Enables easier cleanup during development and testing

## Test plan
- [ ] Verify Terraform plan shows expected changes
- [ ] Test bucket creation and destruction in development environment